### PR TITLE
Add gatekeeper and policy to enforce TLS routes

### DIFF
--- a/.github/workflows/precommit.yaml
+++ b/.github/workflows/precommit.yaml
@@ -1,0 +1,8 @@
+name: Run pre-commit checks
+
+on:
+  pull_request:
+
+jobs:
+  run-linters:
+    uses: ocp-on-nerc/workflows/.github/workflows/precommit.yaml@main

--- a/.github/workflows/validate-manifests.yaml
+++ b/.github/workflows/validate-manifests.yaml
@@ -1,0 +1,8 @@
+name: Validate Kubernetes manifests
+
+on:
+  pull_request:
+
+jobs:
+  validate-manifests:
+    uses: ocp-on-nerc/workflows/.github/workflows/validate-manifests.yaml@main

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,25 @@
+repos:
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.4.2
+    hooks:
+      - id: remove-tabs
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: trailing-whitespace
+      - id: check-merge-conflict
+      - id: end-of-file-fixer
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-json
+      - id: check-symlinks
+      - id: detect-private-key
+
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.30.0
+    hooks:
+      - id: yamllint
+        files: \.(yaml|yml)$
+        types: [file, yaml]
+        entry: yamllint --strict

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,10 @@
+extends: default
+rules:
+  line-length: disable
+  document-start: disable
+  indentation:
+    indent-sequences: whatever
+  hyphens:
+    max-spaces-after: 4
+  truthy:
+    check-keys: false


### PR DESCRIPTION
This PR adds the manifests to deploy [Gatekeeper][] and a basic policy to enforce TLS edge encryption on routes that do not otherwise specify a TLS configuration. The policy is restricted to namespaces labelled with `nerc.mghpcc.org/project=true` (that is, projects created by our onboarding mechanism).

[gatekeeper]: https://github.com/open-policy-agent/gatekeeper

Once this PR merges, we will require an additional change to the apps repository in order to actually deploy these manifests on the cluster.