### PR TITLE
Add gatekeeper and policy to enforce TLS routes #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+This repository is for deploying [Gatekeeper][], part of the Open Policy Agent project. GateKeeper provides support for both the validation and mutation of Kubernetes resources according to specific policies.
+
+There are two applications contained in this repository:
+
+- [`gatekeeper-system`](gatekeeper-system) deploys the GateKeeper service itself.
+- [`policy`](policy) contains our policy definitions.
+
+[gatekeeper]: https://open-policy-agent.github.io/gatekeeper/website/docs/

--- a/gatekeeper-system/base/kustomization.yaml
+++ b/gatekeeper-system/base/kustomization.yaml
@@ -1,0 +1,30 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - https://raw.githubusercontent.com/open-policy-agent/gatekeeper/v3.12.0-rc.0/deploy/gatekeeper.yaml
+
+# Patches per [1] to grant the necessary permissions for running on OpenShift.
+#
+# [1]: https://open-policy-agent.github.io/gatekeeper/website/docs/vendor-specific#running-on-openshift-4x
+patches:
+  - target:
+      kind: Deployment
+    patch: |
+      - op: remove
+        path: /spec/template/spec/containers/0/securityContext/seccompProfile
+  - target:
+      kind: Role
+      name: gatekeeper-manager-role
+    patch: |
+      - op: add
+        path: /rules/-
+        value:
+          apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          resourceNames:
+          - anyuid
+          verbs:
+          - use

--- a/gatekeeper-system/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/gatekeeper-system/overlays/nerc-ocp-prod/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/kustomized: "true"
+
+resources:
+- ../../base

--- a/policy/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/policy/overlays/nerc-ocp-prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- routes-use-tls.yaml

--- a/policy/overlays/nerc-ocp-prod/routes-use-tls.yaml
+++ b/policy/overlays/nerc-ocp-prod/routes-use-tls.yaml
@@ -1,0 +1,29 @@
+# Enable edge encryption for all routes that do not explicitly configure
+# TLS.
+apiVersion: mutations.gatekeeper.sh/v1
+kind: Assign
+metadata:
+  name: routes-use-tls
+spec:
+  applyTo:
+    - groups:
+        - route.openshift.io
+      kinds:
+        - Route
+      versions:
+        - v1
+  match:
+    scope: Namespaced
+
+    # Only apply this policy in projects created through the NERC
+    # onboarding system.
+    namespaceSelector:
+      matchLabels:
+        nerc.mghpcc.org/project: "true"
+  location: spec.tls.termination
+  parameters:
+    pathTests:
+      - subPath: spec.tls.termination
+        condition: MustNotExist
+    assign:
+      value: edge


### PR DESCRIPTION
This PR adds the manifests to deploy [Gatekeeper][] and a basic policy to enforce TLS edge encryption on routes that do not otherwise specify a TLS configuration. The policy is restricted to namespaces labelled with `nerc.mghpcc.org/project=true` (that is, projects created by our onboarding mechanism).

[gatekeeper]: https://github.com/open-policy-agent/gatekeeper

Once this PR merges, we will require an additional change to the apps repository in order to actually deploy these manifests on the cluster.