### PR TITLE
upgrade to latest 3.13.0 version

### DIFF
--- a/gatekeeper-system/base/kustomization.yaml
+++ b/gatekeeper-system/base/kustomization.yaml
@@ -2,17 +2,12 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - https://raw.githubusercontent.com/open-policy-agent/gatekeeper/v3.12.0-rc.0/deploy/gatekeeper.yaml
+  - https://raw.githubusercontent.com/open-policy-agent/gatekeeper/v3.13.0/deploy/gatekeeper.yaml
 
 # Patches per [1] to grant the necessary permissions for running on OpenShift.
 #
 # [1]: https://open-policy-agent.github.io/gatekeeper/website/docs/vendor-specific#running-on-openshift-4x
 patches:
-  - target:
-      kind: Deployment
-    patch: |
-      - op: remove
-        path: /spec/template/spec/containers/0/securityContext/seccompProfile
   - target:
       kind: Role
       name: gatekeeper-manager-role


### PR DESCRIPTION
After upgrading to OpenShift 4.11 the gatekeeper deployment is complaining:
```
'pods "gatekeeper-controller-manager-77df85865b-v6shj" is forbidden:
      violates PodSecurity "restricted:v1.24": seccompProfile (pod or container "manager"
      must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")'
```
This bumps to the latest stable version and also removes the patch that explicitly removes the seccompProfile from the manager container.