### PR TITLE
Fix gatekeeper-system namespace labels

### DIFF
--- a/gatekeeper-system/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/gatekeeper-system/overlays/nerc-ocp-prod/kustomization.yaml
@@ -5,3 +5,17 @@ commonLabels:
 
 resources:
 - ../../base
+
+patches:
+  - patch: |
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: gatekeeper-system
+        labels:
+          pod-security.kubernetes.io/audit: baseline
+          pod-security.kubernetes.io/audit-version: v1.24
+          pod-security.kubernetes.io/enforce: restricted
+          pod-security.kubernetes.io/enforce-version: v1.24
+          pod-security.kubernetes.io/warn: baseline
+          pod-security.kubernetes.io/warn-version: v1.24


### PR DESCRIPTION
It looks like there is a conflict between the pod-security labels on the
gatekeeper namespace between what is configured by the gatekeeper manifests
and what openshift enforces.

This commit makes the generated configuration match openshift.
