### PR TITLE
Add assign-oauth-image gatekeeper policy

### DIFF
--- a/policy/overlays/nerc-ocp-prod/use-internal-oauth-proxy-image.yaml
+++ b/policy/overlays/nerc-ocp-prod/use-internal-oauth-proxy-image.yaml
@@ -1,0 +1,22 @@
+apiVersion: mutations.gatekeeper.sh/v1alpha1
+kind: AssignImage
+metadata:
+  name: use-internal-oauth-proxy-image
+spec:
+  applyTo:
+  - groups: [""]
+    kinds: ["Pod"]
+    versions: ["v1"]
+  location: "spec.containers[name:oauth-proxy].image"
+  parameters:
+    assignDomain: "image-registry.openshift-image-registry.svc:5000"
+    assignPath: "redhat-ods-applications/oauth-proxy"
+    assignTag: ":latest"
+  match:
+    source: "All"
+    scope: Namespaced
+    kinds:
+    - apiGroups: ["*"]
+      kinds: ["Pod"]
+    namespaces: ["rhods-notebooks"]
+    name: jupyter-nb*


### PR DESCRIPTION
This allows the rhods oauth container to pull oauth image from internal registry rather than externally. Relevant issue: https://github.com/nerc-project/operations/issues/506