### PR TITLE
Update internal-oauth-proxy-image

### DIFF
--- a/policy/overlays/nerc-ocp-prod/use-internal-oauth-proxy-image.yaml
+++ b/policy/overlays/nerc-ocp-prod/use-internal-oauth-proxy-image.yaml
@@ -18,5 +18,4 @@ spec:
     kinds:
     - apiGroups: ["*"]
       kinds: ["Pod"]
-    namespaces: ["rhods-notebooks"]
-    name: jupyter-nb*
+    namespaces: ["rhods-notebooks", "ope-rhods-testing-1fef2f"]


### PR DESCRIPTION
This adds the internal-oauth-proxy-image policy to the ope-rhods-testing namespace and removes the name match so that it applies to all pods in the namespace