### PR TITLE
use-internal-oauth-proxy-image will only apply to pods that have an oauth-proxy container already present

### DIFF
--- a/policy/overlays/nerc-ocp-prod/use-internal-oauth-proxy-image.yaml
+++ b/policy/overlays/nerc-ocp-prod/use-internal-oauth-proxy-image.yaml
@@ -12,10 +12,13 @@ spec:
     assignDomain: "image-registry.openshift-image-registry.svc:5000"
     assignPath: "redhat-ods-applications/oauth-proxy"
     assignTag: ":latest"
+    pathTests:
+    - subPath: "spec.containers[name:oauth-proxy].image"
+      condition: MustExist
   match:
     source: "All"
     scope: Namespaced
     kinds:
     - apiGroups: ["*"]
       kinds: ["Pod"]
-    namespaces: ["rhods-notebooks", "ope-rhods-testing-1fef2f"]
+    namespaces: ["rhods-notebooks"]


### PR DESCRIPTION
Currently the use-internal-oauth-proxy-image policy will apply to all pods even if they don't have an oauth-proxy container. This leads to issues with pods created from sources other than RHOAI since it tries to pull the oauth-proxy image when it should not be. This PR will make it so this policy only applies to pods with an oauth-proxy container already present.