### PR TITLE
Allow individual projects to opt out of mandatory tls routes

### DIFF
--- a/policy/overlays/nerc-ocp-prod/routes-use-tls.yaml
+++ b/policy/overlays/nerc-ocp-prod/routes-use-tls.yaml
@@ -16,10 +16,14 @@ spec:
     scope: Namespaced
 
     # Only apply this policy in projects created through the NERC
-    # onboarding system.
+    # onboarding system. Allow individual projects to opt out of
+    # enforcement.
     namespaceSelector:
-      matchLabels:
-        nerc.mghpcc.org/project: "true"
+      matchExpressions:
+      - key: nerc.mghpcc.org/project
+        operator: Exists
+      - key: nerc.mghpcc.org/allow-unencrypted-routes
+        operator: DoesNotExist
   location: spec.tls.termination
   parameters:
     pathTests:


### PR DESCRIPTION
Update the routes-use-tls policy so that individual projects
can opt out of enforcement. This is necessary to support
ACME HTTP-01 challenges.

Part of nerc-project/operations#814
