### PR TITLE
Update ope class validation constraint & constrainttemplate 

### DIFF
--- a/policy/overlays/nerc-ocp-prod/validate-class-example.yaml
+++ b/policy/overlays/nerc-ocp-prod/validate-class-example.yaml
@@ -14,7 +14,4 @@ spec:
   parameters:
     image: "image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/ucsls-f24:latest"
     image_name: "ucsls-F24"
-    cpuLimit: "2"
-    memLimit: "8Gi"
-    cpuRequest: "1"
-    memRequest: "8Gi"
+    resource_size: "Small"

--- a/policy/overlays/nerc-ocp-prod/validate-class-example.yaml
+++ b/policy/overlays/nerc-ocp-prod/validate-class-example.yaml
@@ -12,6 +12,9 @@ spec:
       matchLabels:
         nerc.mghpcc.org/class: fake_class
   parameters:
-    image: "image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/ucsls-f24:latest"
-    image_name: "ucsls-F24"
-    resource_size: "Small"
+    allowed_images:
+      - image: "image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/ucsls-f24:latest"
+        name: "ucsls-F24"
+      - image: "image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/base-ope-image:latest"
+        name: "Base OPE Image"
+    resource_size: "X Small"

--- a/policy/overlays/nerc-ocp-prod/validate-class-example.yaml
+++ b/policy/overlays/nerc-ocp-prod/validate-class-example.yaml
@@ -7,14 +7,18 @@ spec:
     kinds:
       - apiGroups: [""]
         kinds: ["Pod"]
-    namespaces: ["rhods-notebooks"]
-    labelSelector:
-      matchLabels:
-        nerc.mghpcc.org/class: fake_class
+    namespaces: ["ope-rhods-testing-1fef2f"]
+    # Removed labelSelector to match all pods, but we can add it back if needed for specific classes
+    # labelSelector:
+    #   matchLabels:
+    #     nerc.mghpcc.org/class: example_class
   parameters:
     allowed_images:
-      - image: "image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/ucsls-f24:latest"
-        name: "ucsls-F24"
       - image: "image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/base-ope-image:latest"
         name: "Base OPE Image"
-    resource_size: "X Small"
+        resource_size: "X Small"
+        gpu_count: 0
+      - image: "image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/ucsls-f24:latest"
+        name: "ucsls-F24"
+        resource_size: "Small"
+        gpu_count: 1

--- a/policy/overlays/nerc-ocp-prod/validate-ope-pods-constrainttemplate.yaml
+++ b/policy/overlays/nerc-ocp-prod/validate-ope-pods-constrainttemplate.yaml
@@ -10,10 +10,16 @@ spec:
       validation:
         openAPIV3Schema:
           properties:
-            image:
-              type: string
-            image_name:
-              type: string
+            allowed_images:
+              type: array
+              items:
+                type: object
+                properties:
+                  image:
+                    type: string
+                  name:
+                    type: string
+                required: ["image", "name"]
             resource_size:
               type: string
               enum: ["X Small", "Small", "Medium", "Large", "X Large"]
@@ -65,16 +71,27 @@ spec:
           }
         }
 
+        # Check if the provided image is in the allowed list
+        is_allowed_image(provided) {
+          allowed := input.parameters.allowed_images[_]
+          provided == allowed.image
+        }
+
+        # Get allowed image names for error message
+        get_allowed_image_names = names {
+          names := concat(", ", [img.name | img := input.parameters.allowed_images[_]])
+        }
+
         # Verify class image
         violation[{"msg": msg}] {
           container := input.review.object.spec.containers[_]
           env_var := container.env[_]
           env_var.name == "JUPYTER_IMAGE"
           provided := env_var.value
-          required := input.parameters.image
-          provided != required
+          not is_allowed_image(provided)
 
-          msg := sprintf("Must use %s image with %s resource size", [input.parameters.image_name, input.parameters.resource_size])
+          allowed_names := get_allowed_image_names
+          msg := sprintf("Must use one of these images: [%s] with %s resource size", [allowed_names, input.parameters.resource_size])
         }
 
         # Verify resource size
@@ -96,5 +113,6 @@ spec:
             memRequest != resource_values.memRequest
           ])
 
-          msg := sprintf("Must use %s image with %s resource size", [input.parameters.image_name, size])
+          allowed_names := get_allowed_image_names
+          msg := sprintf("Must use one of these images: [%s] with %s resource size", [allowed_names, size])
         }

--- a/policy/overlays/nerc-ocp-prod/validate-ope-pods-constrainttemplate.yaml
+++ b/policy/overlays/nerc-ocp-prod/validate-ope-pods-constrainttemplate.yaml
@@ -19,16 +19,18 @@ spec:
                     type: string
                   name:
                     type: string
-                required: ["image", "name"]
-            resource_size:
-              type: string
-              enum: ["X Small", "Small", "Medium", "Large", "X Large"]
+                  resource_size:
+                    type: string
+                    enum: ["X Small", "Small", "Medium", "Large", "X Large"]
+                  gpu_count:
+                    type: integer
+                required: ["image", "name", "resource_size", "gpu_count"]
   targets:
     - target: admission.k8s.gatekeeper.sh
       rego: |
         package K8sRequiredOPEPod
 
-        # Function to get resource values based on size
+        # Function to get resource values based on size (string)
         get_resource_values(size) = values {
           size == "X Small"
           values := {
@@ -71,48 +73,54 @@ spec:
           }
         }
 
-        # Check if the provided image is in the allowed list
-        is_allowed_image(provided) {
-          allowed := input.parameters.allowed_images[_]
-          provided == allowed.image
+        # Find the image configuration for the provided image
+        find_image_config(provided) = config {
+          config := input.parameters.allowed_images[_]
+          provided == config.image
         }
 
-        # Get allowed image names for error message
-        get_allowed_image_names = names {
-          names := concat(", ", [img.name | img := input.parameters.allowed_images[_]])
-        }
-
-        # Verify class image
+        # Verify container image
         violation[{"msg": msg}] {
-          container := input.review.object.spec.containers[_]
+          container := input.review.object.spec.containers[0]
           env_var := container.env[_]
           env_var.name == "JUPYTER_IMAGE"
           provided := env_var.value
-          not is_allowed_image(provided)
+          not find_image_config(provided)
 
-          allowed_names := get_allowed_image_names
-          msg := sprintf("Must use one of these images: [%s] with %s resource size", [allowed_names, input.parameters.resource_size])
+          allowed_names := concat(", ", [sprintf("%s (%s resource size, %d GPUs)", [img.name, img.resource_size, img.gpu_count]) | img := input.parameters.allowed_images[_]])
+          msg := sprintf("Must use one of these images: [%s]", [allowed_names])
         }
 
-        # Verify resource size
+        # Validate resources
         violation[{"msg": msg}] {
-          size := input.parameters.resource_size
-          resource_values := get_resource_values(size)
-
           container := input.review.object.spec.containers[0]
+          env_var := container.env[_]
+          env_var.name == "JUPYTER_IMAGE"
+          provided := env_var.value
 
+          image_config := find_image_config(provided)
+          resource_values := get_resource_values(image_config.resource_size)
+          gpu_count := image_config.gpu_count
+
+          # Get actual resource values from container
           cpuLimit := container.resources.limits.cpu
           memLimit := container.resources.limits.memory
           cpuRequest := container.resources.requests.cpu
           memRequest := container.resources.requests.memory
+          actual_gpu_request := object.get(container.resources.requests, "nvidia.com/gpu", "0")
+          actual_gpu_limit := object.get(container.resources.limits, "nvidia.com/gpu", "0")
 
+          # Violation if any resource doesn't match the required values
           any([
             cpuLimit != resource_values.cpuLimit,
             memLimit != resource_values.memLimit,
             cpuRequest != resource_values.cpuRequest,
-            memRequest != resource_values.memRequest
+            memRequest != resource_values.memRequest,
+            actual_gpu_request != sprintf("%d", [gpu_count]),
+            actual_gpu_limit != sprintf("%d", [gpu_count])
           ])
 
-          allowed_names := get_allowed_image_names
-          msg := sprintf("Must use one of these images: [%s] with %s resource size", [allowed_names, size])
+          # Generate error message
+          allowed_names := concat(", ", [sprintf("%s (%s resource size, %d GPUs)", [img.name, img.resource_size, img.gpu_count]) | img := input.parameters.allowed_images[_]])
+          msg := sprintf("Must use one of these images: [%s]", [allowed_names])
         }

--- a/policy/overlays/nerc-ocp-prod/validate-ope-pods-constrainttemplate.yaml
+++ b/policy/overlays/nerc-ocp-prod/validate-ope-pods-constrainttemplate.yaml
@@ -14,52 +14,56 @@ spec:
               type: string
             image_name:
               type: string
-            cpuLimit:
+            resource_size:
               type: string
-            memLimit:
-              type: string
-            cpuRequest:
-              type: string
-            memRequest:
-              type: string
+              enum: ["X Small", "Small", "Medium", "Large", "X Large"]
   targets:
     - target: admission.k8s.gatekeeper.sh
       rego: |
         package K8sRequiredOPEPod
 
-        # Function to determine the resource size
-        resource_size(cpuLimit, memLimit, cpuRequest, memRequest) = size {
-          cpuLimit == "1"
-          memLimit == "4Gi"
-          cpuRequest == "100m"
-          memRequest == "1Gi"
-          size := "X Small"
-        } else = size {
-          cpuLimit == "2"
-          memLimit == "8Gi"
-          cpuRequest == "1"
-          memRequest == "8Gi"
-          size := "Small"
-        } else = size {
-          cpuLimit == "6"
-          memLimit == "24Gi"
-          cpuRequest == "3"
-          memRequest == "24Gi"
-          size := "Medium"
-        } else = size {
-          cpuLimit == "14"
-          memLimit == "56Gi"
-          cpuRequest == "7"
-          memRequest == "56Gi"
-          size := "Large"
-        } else = size {
-          cpuLimit == "30"
-          memLimit == "120Gi"
-          cpuRequest == "15"
-          memRequest == "120Gi"
-          size := "X Large"
+        # Function to get resource values based on size
+        get_resource_values(size) = values {
+          size == "X Small"
+          values := {
+            "cpuLimit": "1",
+            "memLimit": "4Gi",
+            "cpuRequest": "100m",
+            "memRequest": "1Gi"
+          }
+        } else = values {
+          size == "Small"
+          values := {
+            "cpuLimit": "2",
+            "memLimit": "8Gi",
+            "cpuRequest": "1",
+            "memRequest": "8Gi"
+          }
+        } else = values {
+          size == "Medium"
+          values := {
+            "cpuLimit": "6",
+            "memLimit": "24Gi",
+            "cpuRequest": "3",
+            "memRequest": "24Gi"
+          }
+        } else = values {
+          size == "Large"
+          values := {
+            "cpuLimit": "14",
+            "memLimit": "56Gi",
+            "cpuRequest": "7",
+            "memRequest": "56Gi"
+          }
+        } else = values {
+          size == "X Large"
+          values := {
+            "cpuLimit": "30",
+            "memLimit": "120Gi",
+            "cpuRequest": "15",
+            "memRequest": "120Gi"
+          }
         }
-
 
         # Verify class image
         violation[{"msg": msg}] {
@@ -70,30 +74,27 @@ spec:
           required := input.parameters.image
           provided != required
 
-          size := resource_size(input.parameters.cpuLimit, input.parameters.memLimit, input.parameters.cpuRequest, input.parameters.memRequest)
-          msg := sprintf("Must use %s image with %s resource size", [input.parameters.image_name, size])
+          msg := sprintf("Must use %s image with %s resource size", [input.parameters.image_name, input.parameters.resource_size])
         }
 
         # Verify resource size
         violation[{"msg": msg}] {
-          requiredCpuLimit := input.parameters.cpuLimit
-          requiredMemoryLimit := input.parameters.memLimit
-          requiredCpuRequest := input.parameters.cpuRequest
-          requiredMemoryRequest := input.parameters.memRequest
+          size := input.parameters.resource_size
+          resource_values := get_resource_values(size)
 
           container := input.review.object.spec.containers[0]
-
 
           cpuLimit := container.resources.limits.cpu
           memLimit := container.resources.limits.memory
           cpuRequest := container.resources.requests.cpu
           memRequest := container.resources.requests.memory
 
-          requiredCpuLimit != cpuLimit
-          requiredMemoryLimit != memLimit
-          requiredCpuRequest != cpuRequest
-          requiredMemoryRequest != memRequest
+          any([
+            cpuLimit != resource_values.cpuLimit,
+            memLimit != resource_values.memLimit,
+            cpuRequest != resource_values.cpuRequest,
+            memRequest != resource_values.memRequest
+          ])
 
-          size := resource_size(input.parameters.cpuLimit, input.parameters.memLimit, input.parameters.cpuRequest, input.parameters.memRequest)
           msg := sprintf("Must use %s image with %s resource size", [input.parameters.image_name, size])
         }


### PR DESCRIPTION
Adds three commits that do the following:

- Simplify constraint parameters:
Rather than having to specify the exact numerical cpu and mem requests
and limits, you can now just specify string size mapping to those
numbers "X Small", "Small" etc.

- ope constraint: support multiple allowed images
Rather than being restricted to selecting only 1 image, can now specify
multiple allowed images in a class validation constraint.

- Ability to specify resource size PER image: We can now specify which
  resource sizes are allowed for a specific image. Whereas before you
could only specify one resource size for all images.

- Ability to specify # of GPUs an image is allowed: We are now able to
  specify how many GPUs a specific image is allowed to claim.
