### PR TITLE
gatekeeper v3.20.1

### DIFF
--- a/gatekeeper-system/base/kustomization.yaml
+++ b/gatekeeper-system/base/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - https://raw.githubusercontent.com/open-policy-agent/gatekeeper/v3.17.0/deploy/gatekeeper.yaml
+  - https://raw.githubusercontent.com/open-policy-agent/gatekeeper/v3.20.1/deploy/gatekeeper.yaml
 
 # Patches per [1] to grant the necessary permissions for running on OpenShift.
 #

--- a/gatekeeper-system/base/kustomization.yaml
+++ b/gatekeeper-system/base/kustomization.yaml
@@ -14,6 +14,16 @@ patches:
       - op: remove
         path: /spec/template/spec/containers/0/securityContext/runAsUser
   - target:
+      kind: Deployment
+      name: gatekeeper-audit
+    patch: |
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/memory
+        value: 1Gi
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/requests/memory
+        value: 1Gi
+  - target:
       kind: Role
       name: gatekeeper-manager-role
     patch: |

--- a/gatekeeper-system/overlays/nerc-ocp-edu/kustomization.yaml
+++ b/gatekeeper-system/overlays/nerc-ocp-edu/kustomization.yaml
@@ -14,8 +14,8 @@ patches:
         name: gatekeeper-system
         labels:
           pod-security.kubernetes.io/audit: baseline
-          pod-security.kubernetes.io/audit-version: v1.24
+          pod-security.kubernetes.io/audit-version: v1.32
           pod-security.kubernetes.io/enforce: restricted
-          pod-security.kubernetes.io/enforce-version: v1.24
+          pod-security.kubernetes.io/enforce-version: v1.32
           pod-security.kubernetes.io/warn: baseline
-          pod-security.kubernetes.io/warn-version: v1.24
+          pod-security.kubernetes.io/warn-version: v1.32

--- a/gatekeeper-system/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/gatekeeper-system/overlays/nerc-ocp-prod/kustomization.yaml
@@ -14,8 +14,8 @@ patches:
         name: gatekeeper-system
         labels:
           pod-security.kubernetes.io/audit: baseline
-          pod-security.kubernetes.io/audit-version: v1.24
+          pod-security.kubernetes.io/audit-version: v1.32
           pod-security.kubernetes.io/enforce: restricted
-          pod-security.kubernetes.io/enforce-version: v1.24
+          pod-security.kubernetes.io/enforce-version: v1.32
           pod-security.kubernetes.io/warn: baseline
-          pod-security.kubernetes.io/warn-version: v1.24
+          pod-security.kubernetes.io/warn-version: v1.32


### PR DESCRIPTION
The gatekeeper pods are busted currently on ocp-test, ocp-prod, and ocp-edu clusters. This upgrades the gatekeeper installation to the latest stable v3.20.1 version and bumps the policy audit version for k8s to 1.32 to match OCP 4.19 minor version of kubernetes.

I've run this by hand on ocp-test and it appears to have fixed the gatekeeper-audit pod crashloopbackoff.