### PR TITLE
edu: add course policy manifests

### DIFF
--- a/policy/overlays/nerc-ocp-edu/kustomization.yaml
+++ b/policy/overlays/nerc-ocp-edu/kustomization.yaml
@@ -2,3 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - routes-use-tls.yaml
+- validate-ope-pods-constrainttemplate.yaml
+- validate-cs210.yaml
+- validate-cs599.yaml


### PR DESCRIPTION
This adds the necessary manifests for restricting images to course-approved images for cs210 and cs599

@DanNiESh I've left out `use-internal-oauth-proxy-image.yaml` for now until we figure out whether this is required or not.