### PR TITLE
edu: enforce internal oauth-proxy image

### DIFF
--- a/policy/overlays/nerc-ocp-edu/kustomization.yaml
+++ b/policy/overlays/nerc-ocp-edu/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - routes-use-tls.yaml
+- use-internal-oauth-proxy-image.yaml
 - validate-ope-pods-constrainttemplate.yaml
 - validate-cs210.yaml
 - validate-cs599.yaml


### PR DESCRIPTION
This forces pod containers matching name oauth-proxy to use the oauth-proxy image in the local OCP image registry.

This was left out in #20 but we've determined we need it after all.